### PR TITLE
Fix BIOS extension rom caller code

### DIFF
--- a/bios.asm
+++ b/bios.asm
@@ -165,7 +165,7 @@ erase_ints2:
 	mov ax, 0x40
 	mov ds, ax
 	mov word [bios_temp + 2], 0xC000
-	mov word [bios_temp], 2
+	mov word [bios_temp], 3
 scan_roms:
 	mov ax, [bios_temp + 2]
 	mov es, ax
@@ -620,7 +620,7 @@ video_static_table:
 	dd 0 	; IBM reserved
 	db 0x07 ; scan lines suppported: bit 0 = 200, 1 = 350, 2 = 400
 	db 0x08 ; font blocks available in text mode (4 = EGA, 8 = VGA)
-	db 0x02 ; maximum active font blocks in text mode (2 = EGA или VGA)
+	db 0x02 ; maximum active font blocks in text mode (2 = EGA пїЅпїЅпїЅ VGA)
 	db 0xfd ; misc support flags
 	db 0x08	; misc capabilities (DCC support)
 	dw 0x00 ; reserved


### PR DESCRIPTION
While working on the BIOS for my 486 homebrew board, which is derived from this project, I wondered why some graphics cards wouldn't initialize. For example, the VBIOS for the Cirrus Logic GD5401 was problematic. Upon further inspection, I discovered that the CPU begins executing random code and freezes at the beginning of the VBIOS ROM. After examining the debugger, I noticed that the BIOS jumps to 0xC000:0002 (ROM extension size byte) instead of 0xC000:0003. This seems to work with some GPUs VBIOSes where the size is interpreted as a single byte instruction, but not if it's interpreted as an instruction with two or more bytes. This is what happens with the GD5401 VBIOS. The fix is to change the execution entry point and in the end that improves overall compatibility.